### PR TITLE
Comma-spacing rule added to rules/style.js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/rules/style.js
+++ b/rules/style.js
@@ -6,7 +6,9 @@ module.exports = {
     'camelcase': [2, {'properties': 'never'}],
     // enforce one true comma style
     'comma-style': [2, 'last'],
-    // enforce newline at the end of file, with no multiple empty lines
+    // enforce spacing after array element and functions
+		'comma-spacing': [2, {'before':false, 'after': true}],
+		// enforce newline at the end of file, with no multiple empty lines
     'eol-last': 2,
     // specify whether double or single quotes should be used in JSX attributes
     'jsx-quotes': 2,

--- a/rules/style.js
+++ b/rules/style.js
@@ -7,8 +7,8 @@ module.exports = {
     // enforce one true comma style
     'comma-style': [2, 'last'],
     // enforce spacing after array element and functions
-		'comma-spacing': [2, {'before':false, 'after': true}],
-		// enforce newline at the end of file, with no multiple empty lines
+    'comma-spacing': [2, {'before':false, 'after': true}],
+    // enforce newline at the end of file, with no multiple empty lines
     'eol-last': 2,
     // specify whether double or single quotes should be used in JSX attributes
     'jsx-quotes': 2,


### PR DESCRIPTION
* Add editorconfig to help write rules without spacing issues like one of my commits
* Add comma-spacing rule to styles.js to help with function(arg1, arg2) stuff along with [1, 2]